### PR TITLE
fix(components): removed scope from modules

### DIFF
--- a/app-components/src/dev/java/org/synsystems/onlypass/components/EnvironmentModule.java
+++ b/app-components/src/dev/java/org/synsystems/onlypass/components/EnvironmentModule.java
@@ -4,7 +4,6 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module
-@AppScope
 public class EnvironmentModule {
   @Provides
   @AppScope

--- a/app-components/src/externalTesting/java/org/synsystems/onlypass/components/EnvironmentModule.java
+++ b/app-components/src/externalTesting/java/org/synsystems/onlypass/components/EnvironmentModule.java
@@ -4,7 +4,6 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module
-@AppScope
 public class EnvironmentModule {
   @Provides
   @AppScope

--- a/app-components/src/internalTesting/java/org/synsystems/onlypass/components/EnvironmentModule.java
+++ b/app-components/src/internalTesting/java/org/synsystems/onlypass/components/EnvironmentModule.java
@@ -4,7 +4,6 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module
-@AppScope
 public class EnvironmentModule {
   @Provides
   @AppScope

--- a/app-components/src/prod/java/org/synsystems/onlypass/components/EnvironmentModule.java
+++ b/app-components/src/prod/java/org/synsystems/onlypass/components/EnvironmentModule.java
@@ -4,7 +4,6 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module
-@AppScope
 public class EnvironmentModule {
   @Provides
   @AppScope


### PR DESCRIPTION
:desc Scoped modules are a compiler error in the latest version of dagger.